### PR TITLE
Add commands for snippets activation and deactivation

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -26,6 +26,22 @@ export default class SnippetCommandsPlugin extends Plugin {
           customCss.setCssEnabledStatus(snippet, !customCss.enabledSnippets.has(snippet));
         }
       });
+
+      this.addCommand({
+        id: `snippet-command-activate-${snippet}`,
+        name: `Activate ${snippet}`,
+        callback: () => {
+          customCss.setCssEnabledStatus(snippet, true);
+        }
+      });
+
+      this.addCommand({
+        id: `snippet-command-deactivate-${snippet}`,
+        name: `Deactivate ${snippet}`,
+        callback: () => {
+          customCss.setCssEnabledStatus(snippet, false);
+        }
+      });
     });
     this.addCommand({
       id: `snippet-command-reload-all-snippets`,


### PR DESCRIPTION
When combining commands in macros (using [Commander plugin](https://github.com/phibr0/obsidian-commander)), it's useful to be able to activate or deactivate snippets, not just toggling, to avoid getting out of sync with other statuses (e.g.: typewriter mode).